### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,9 @@ name: Run linters
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wozjac/vscode-ui5-api-reference/security/code-scanning/7](https://github.com/wozjac/vscode-ui5-api-reference/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow only runs linters and does not require write access, we will set `contents: read` as the minimal permission. This ensures the workflow has only the access it needs to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
