### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/wozjac/vscode-ui5-api-reference/security/code-scanning/5](https://github.com/wozjac/vscode-ui5-api-reference/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for most steps, and `contents: write` is not required. Additionally, the `pull-requests: write` permission is not needed unless explicitly stated. 

The `permissions` block will be added after the `name` field and before the `on` field to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
